### PR TITLE
Support FieldPerp in DataFile

### DIFF
--- a/boututils/datafile.py
+++ b/boututils/datafile.py
@@ -478,7 +478,7 @@ class DataFile_netCDF(DataFile):
             ('x', 'y', 'z'): "Field3D",
             ('x', 'y'): "Field2D",
             ('x', 'z'): "FieldPerp",
-            ('x'): "ArrayX",
+            ('x',): "ArrayX",
             (): "scalar",
         }
 
@@ -493,7 +493,7 @@ class DataFile_netCDF(DataFile):
             "Field3D": ('x', 'y', 'z'),
             "Field2D": ('x', 'y'),
             "FieldPerp": ('x', 'z'),
-            "ArrayX": ('x'),
+            "ArrayX": ('x',),
             "scalar": (),
         }
 
@@ -788,7 +788,7 @@ class DataFile_HDF5(DataFile):
             "Field3D": ('x', 'y', 'z'),
             "FieldPerp": ('x', 'z'),
             "Field2D": ('x', 'y'),
-            "ArrayX": ('x'),
+            "ArrayX": ('x',),
             "scalar": (),
         }
         try:

--- a/boututils/datafile.py
+++ b/boututils/datafile.py
@@ -473,13 +473,31 @@ class DataFile_netCDF(DataFile):
         dims_dict = {
             ('t', 'x', 'y', 'z'): "Field3D_t",
             ('t', 'x', 'y'): "Field2D_t",
+            ('t', 'x', 'z'): "FieldPerp_t",
             ('t',): "scalar_t",
             ('x', 'y', 'z'): "Field3D",
             ('x', 'y'): "Field2D",
+            ('x', 'z'): "FieldPerp",
+            ('x'): "ArrayX",
             (): "scalar",
         }
 
         return dims_dict.get(dims, None)
+
+    def _bout_dimensions_from_type(self, bout_type):
+        dims_dict = {
+            "Field3D_t": ('t', 'x', 'y', 'z'),
+            "Field2D_t": ('t', 'x', 'y'),
+            "FieldPerp_t": ('t', 'x', 'z'),
+            "scalar_t": ('t',),
+            "Field3D": ('x', 'y', 'z'),
+            "Field2D": ('x', 'y'),
+            "FieldPerp": ('x', 'z'),
+            "ArrayX": ('x'),
+            "scalar": (),
+        }
+
+        return dims_dict.get(bout_type, None)
 
     def write(self, name, data, info=False):
 
@@ -523,11 +541,15 @@ class DataFile_netCDF(DataFile):
             # Not found, so add.
 
             # Get dimensions
-            defdims = [(),
-                       ('t',),
-                       ('x', 'y'),
-                       ('x', 'y', 'z'),
-                       ('t', 'x', 'y', 'z')]
+            try:
+                defdims = self._bout_dimensions_from_type(data.attributes['bout_type'])
+            except AttributeError:
+                defdims_list = [(),
+                                ('t',),
+                                ('x', 'y'),
+                                ('x', 'y', 'z'),
+                                ('t', 'x', 'y', 'z')]
+                defdims = defdims_list[len(s)]
 
             def find_dim(dim):
                 # Find a dimension with given name and size
@@ -585,7 +607,7 @@ class DataFile_netCDF(DataFile):
                 return name
 
             # List of (size, 'name') tuples
-            dlist = list(zip(s, defdims[len(s)]))
+            dlist = list(zip(s, defdims))
             # Get new list of variables, and turn into a tuple
             dims = tuple(map(find_dim, dlist))
 
@@ -760,10 +782,13 @@ class DataFile_HDF5(DataFile):
         bout_type = self.bout_type(varname)
         dims_dict = {
             "Field3D_t": ('t', 'x', 'y', 'z'),
+            "FieldPerp_t": ('t', 'x', 'z'),
             "Field2D_t": ('t', 'x', 'y'),
             "scalar_t": ('t',),
             "Field3D": ('x', 'y', 'z'),
+            "FieldPerp": ('x', 'z'),
             "Field2D": ('x', 'y'),
+            "ArrayX": ('x'),
             "scalar": (),
         }
         try:
@@ -866,7 +891,7 @@ class DataFile_HDF5(DataFile):
             print("Creating variable '" + name +
                   "' with bout_type '" + bout_type + "'")
 
-        if bout_type in ["Field3D_t", "Field2D_t", "scalar_t"]:
+        if bout_type in ["Field3D_t", "Field2D_t", "FieldPerp_t", "scalar_t"]:
             # time evolving fields
             shape = list(data.shape)
             # set time dimension to None to make unlimited
@@ -896,7 +921,7 @@ class DataFile_HDF5(DataFile):
         try:
             for attrname in data.attributes:
                 attrval = data.attributes[attrname]
-                if type(attrval == str):
+                if type(attrval) == str:
                     attrval = attrval.encode(encoding='utf-8')
                 self.handle[name].attrs.create(attrname, attrval)
         except AttributeError:


### PR DESCRIPTION
Adds support for `FieldPerp`s to the `DataFile` class, allowing `boutdata.collect` and `boutdata.restart` to support `FieldPerp`s.

Sorry, I forgot to copy these updates over from https://github.com/boutproject/BOUT-dev/pull/1699/files#diff-68af166dafa001ad8801ac4c92d14b9e.