### PR TITLE
Fix typo in showdata which gave .gif files double extensions.

### DIFF
--- a/boututils/showdata.py
+++ b/boututils/showdata.py
@@ -688,7 +688,7 @@ def showdata(vars, titles=[], legendlabels=[], surf=[], polar=[], tslice=0, t_ar
                      print('Save failed: Check ffmpeg path')
                      raise
         elif movietype == 'gif':
-            anim.save(movie+'.gif',writer = 'imagemagick', fps=fps, dpi=dpi)
+            anim.save(movie+,writer = 'imagemagick', fps=fps, dpi=dpi)
         else:
             raise ValueError("Unrecognized file type for movie. Supported types are .mp4 and .gif")
 


### PR DESCRIPTION
Small typo in showdata led to files being named 'filename.gif.gif'. 

mirroring a PR from BOUT-dev