### PR TITLE
When getting version with setuptools_scm, resolve __file__ path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ addons:
     - libxkbcommon-x11-0
 
 install:
-  - pip install codecov pytest-cov numpy matplotlib scipy h5py future netCDF4 setuptools_scm
+  - pip install setuptools_scm
+  - pip install .
 
 script:
   - pytest --cov=./

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
 
 install:
   - pip uninstall -y numpy
-  - pip install codecov pytest-cov
+  - pip install codecov pytest-cov setuptools_scm
 
 script:
   - pytest --cov=./

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ addons:
 
 install:
   - pip uninstall -y numpy
-  - pip install boututils
   - pip install codecov pytest-cov
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ addons:
     - libxkbcommon-x11-0
 
 install:
-  - pip uninstall -y numpy
-  - pip install codecov pytest-cov setuptools_scm
+  - pip install codecov pytest-cov numpy matplotlib scipy h5py future netCDF4 setuptools_scm
 
 script:
   - pytest --cov=./

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ addons:
     - libxkbcommon-x11-0
 
 install:
-  - pip install setuptools_scm
+  - pip install setuptools_scm pytest-cov
   - pip install .
 
 script:

--- a/boututils/__init__.py
+++ b/boututils/__init__.py
@@ -57,4 +57,6 @@ except PackageNotFoundError:
         print(error_info)
         raise ModuleNotFoundError(str(e) + ". " + error_info)
     else:
-        __version__ = get_version(root="..", relative_to=__file__)
+        from pathlib import Path
+        path = Path(__file__).resolve()
+        __version__ = get_version(root="..", relative_to=path)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
                       'scipy',
                       'h5py',
                       'future',
-                      'netCDF4'
+                      'netCDF4',
                       "importlib-metadata ; python_version<'3.8'"],
     extras_require={
                     'mayavi': ['mayavi', 'PyQt5']},


### PR DESCRIPTION
If symlinks to the boututils directory are used, they can confuse the version-number finding function. Fix this by using pathlib.Path.resolve() to resolve all symlinks. This is needed for https://github.com/boutproject/BOUT-dev/pull/2196.