### PR TITLE
Use 'NETCDF4' as default format for DataFile

### DIFF
--- a/boututils/datafile.py
+++ b/boututils/datafile.py
@@ -83,7 +83,7 @@ class DataFile(object):
     impl = None
 
     def __init__(
-        self, filename=None, write=False, create=False, format="NETCDF3_64BIT", **kwargs
+        self, filename=None, write=False, create=False, format="NETCDF4", **kwargs
     ):
         """
 


### PR DESCRIPTION
`NETCDF4` format is pretty universally supported now, and is probably the least surprising default.

Technically I guess this is a breaking change - it will change the file format for some workflows - but all our utilities that read 'NETCDF3' files will read 'NETCDF4' so this shouldn't cause any problems.