### PR TITLE
DataFile.get() method

### DIFF
--- a/boututils/datafile.py
+++ b/boututils/datafile.py
@@ -314,6 +314,12 @@ class DataFile(object):
     def write_file_attribute(self, name, value):
         return self.impl.write_file_attribute(name, value)
 
+    def get(self, name, default=None):
+        if default is None or name in self.keys():
+            return self[name]
+        else:
+            return default
+
     def __getitem__(self, name):
         return self.impl.__getitem__(name)
 


### PR DESCRIPTION
Means DataFile behaves more like a dict, and allows passing a default in case the value is missing.

Needed for tidy-up in https://github.com/boutproject/boutdata/pull/65.