### PR TITLE
Fix bug in computation of derivative with DFT

### DIFF
--- a/boututils/calculus.py
+++ b/boututils/calculus.py
@@ -44,18 +44,20 @@ def deriv(*args, **kwargs):
 
     n = var.size
     if periodic:
+        # assume uniform grid 
+        dx = x[1] - x[0]
         # Use FFTs to take derivatives
         f = rfft(var)
         f[0] = 0.0  # Zero constant term
         if n % 2 == 0:
             # Even n
             for i in arange(1, old_div(n, 2)):
-                f[i] *= 2.0j * pi * float(i) / float(n)
+                f[i] *= 2.0j * pi * float(i) / (float(n)*dx)
             f[-1] = 0.0  # Nothing from Nyquist frequency
         else:
             # Odd n
             for i in arange(1, old_div((n - 1), 2) + 1):
-                f[i] *= 2.0j * pi * float(i) / float(n)
+                f[i] *= 2.0j * pi * float(i) / (float(n)*dx)
         return irfft(f)
     else:
         # Non-periodic function


### PR DESCRIPTION
This fixes the bug referenced here https://github.com/boutproject/boututils/issues/44#issue-1427487774

It simply computes the correct ordinary wavenumbers if the user has supplied a grid 'x'. Otherwise, if no grid `x` has been supplied, the behaviour of the function is unchanged