### PR TITLE
Revert "Use 'NETCDF4' as default format for DataFile"

### DIFF
--- a/boututils/datafile.py
+++ b/boututils/datafile.py
@@ -82,7 +82,7 @@ class DataFile(object):
     impl = None
 
     def __init__(
-        self, filename=None, write=False, create=False, format="NETCDF4", **kwargs
+        self, filename=None, write=False, create=False, format="NETCDF3_64BIT", **kwargs
     ):
         """
 


### PR DESCRIPTION
This reverts commit 11bb66d96a61e4cf5dd1b160d51ba4b556cc4aee.

Resolves https://github.com/boutproject/BOUT-dev/issues/2663